### PR TITLE
feat(frontend): add main layout with sidebar toggle

### DIFF
--- a/codex-rs/frontend/index.html
+++ b/codex-rs/frontend/index.html
@@ -3,21 +3,51 @@
 <head>
   <meta charset="utf-8" />
   <title>Codex Frontend</title>
+  <style>
+    html, body, #app {
+      height: 100%;
+      margin: 0;
+    }
+    #header {
+      display: flex;
+      gap: 8px;
+      padding: 8px;
+      background: #eee;
+    }
+    #layout {
+      display: grid;
+      grid-template-columns: 250px 1fr;
+      height: calc(100% - 40px);
+    }
+    #sidebar {
+      resize: horizontal;
+      overflow: auto;
+    }
+    #chat {
+      overflow: auto;
+    }
+  </style>
 </head>
 <body>
-  <h1>Codex Frontend</h1>
-  <button id="open-settings">Settings</button>
-  <div id="settings-panel" style="display:none"></div>
-  <input id="prompt" type="text" placeholder="Enter prompt" />
-  <button id="send">Send</button>
-  <pre id="response"></pre>
-  <div>
-    <input id="search" type="text" placeholder="Search files" />
-    <ul id="files"></ul>
-  </div>
-  <div>
-    <textarea id="patch" placeholder="Patch text"></textarea>
-    <button id="apply">Apply Patch</button>
+  <div id="app">
+    <div id="header">
+      <button id="toggle-sidebar">Hide Sidebar</button>
+      <button id="open-settings">Settings</button>
+    </div>
+    <div id="layout">
+      <div id="sidebar">
+        <input id="search" type="text" placeholder="Search files" />
+        <ul id="files"></ul>
+        <textarea id="patch" placeholder="Patch text"></textarea>
+        <button id="apply">Apply Patch</button>
+      </div>
+      <div id="chat">
+        <input id="prompt" type="text" placeholder="Enter prompt" />
+        <button id="send">Send</button>
+        <pre id="response"></pre>
+      </div>
+    </div>
+    <div id="settings-panel" style="display:none"></div>
   </div>
   <script type="module" src="main.js"></script>
 </body>

--- a/codex-rs/frontend/main.js
+++ b/codex-rs/frontend/main.js
@@ -1,5 +1,8 @@
 import { invoke } from "@tauri-apps/api/tauri";
 import { SettingsPanel } from "./settings_panel.js";
+import { MainLayout } from "./src/main_layout.js";
+
+new MainLayout();
 
 let conversationId = null;
 

--- a/codex-rs/frontend/src/main_layout.js
+++ b/codex-rs/frontend/src/main_layout.js
@@ -1,0 +1,49 @@
+export class MainLayout {
+  constructor() {
+    this.layout = document.getElementById("layout");
+    this.sidebar = document.getElementById("sidebar");
+    this.chat = document.getElementById("chat");
+    this.toggle = document.getElementById("toggle-sidebar");
+
+    this.sidebarVisible = JSON.parse(
+      localStorage.getItem("sidebarVisible") || "true"
+    );
+    this.sidebarWidth = localStorage.getItem("sidebarWidth") || "250px";
+
+    this.applyState();
+
+    this.toggle.addEventListener("click", () => this.toggleSidebar());
+    this.sidebar.addEventListener("mouseup", () => this.storeWidth());
+    this.sidebar.addEventListener("mouseleave", () => this.storeWidth());
+  }
+
+  applyState() {
+    if (this.sidebarVisible) {
+      this.sidebar.style.display = "block";
+      this.sidebar.style.width = this.sidebarWidth;
+      this.layout.style.gridTemplateColumns = `${this.sidebarWidth} 1fr`;
+      this.toggle.textContent = "Hide Sidebar";
+    } else {
+      this.sidebar.style.display = "none";
+      this.layout.style.gridTemplateColumns = `0 1fr`;
+      this.toggle.textContent = "Show Sidebar";
+    }
+  }
+
+  toggleSidebar() {
+    this.sidebarVisible = !this.sidebarVisible;
+    localStorage.setItem(
+      "sidebarVisible",
+      JSON.stringify(this.sidebarVisible)
+    );
+    this.applyState();
+  }
+
+  storeWidth() {
+    if (!this.sidebarVisible) return;
+    const width = `${this.sidebar.offsetWidth}px`;
+    this.sidebarWidth = width;
+    this.layout.style.gridTemplateColumns = `${width} 1fr`;
+    localStorage.setItem("sidebarWidth", width);
+  }
+}


### PR DESCRIPTION
## Summary
- add MainLayout component to manage sidebar/chat grid layout
- add header toggle for sidebar visibility with persisted width

## Testing
- `pnpm run test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_68be4912787c8324b3fbe5edd6e05755