### PR TITLE
feat(frontend): add FileTree component

### DIFF
--- a/codex-rs/frontend/index.html
+++ b/codex-rs/frontend/index.html
@@ -26,6 +26,9 @@
     #chat {
       overflow: auto;
     }
+    .selected {
+      background: #ddd;
+    }
   </style>
 </head>
 <body>
@@ -36,8 +39,7 @@
     </div>
     <div id="layout">
       <div id="sidebar">
-        <input id="search" type="text" placeholder="Search files" />
-        <ul id="files"></ul>
+        <div id="file-tree"></div>
         <textarea id="patch" placeholder="Patch text"></textarea>
         <button id="apply">Apply Patch</button>
       </div>

--- a/codex-rs/frontend/main.js
+++ b/codex-rs/frontend/main.js
@@ -1,8 +1,11 @@
 import { invoke } from "@tauri-apps/api/tauri";
 import { SettingsPanel } from "./settings_panel.js";
 import { MainLayout } from "./src/main_layout.js";
+import { FileTree } from "./src/components/FileTree.js";
 
 new MainLayout();
+
+const fileTree = new FileTree(document.getElementById("file-tree"));
 
 let conversationId = null;
 
@@ -18,16 +21,8 @@ document.getElementById("send").addEventListener("click", async () => {
   await invoke("send_message", { id: conversationId, message: prompt });
 });
 
-document.getElementById("search").addEventListener("input", async (e) => {
-  const query = e.target.value;
-  const resp = await invoke("search_files", { query, dir: "." });
-  const list = document.getElementById("files");
-  list.innerHTML = "";
-  resp.paths.forEach((p) => {
-    const li = document.createElement("li");
-    li.textContent = p;
-    list.appendChild(li);
-  });
+window.addEventListener("file-open", (e) => {
+  document.getElementById("response").textContent = e.detail.content;
 });
 
 document.getElementById("apply").addEventListener("click", async () => {

--- a/codex-rs/frontend/src/components/FileTree.js
+++ b/codex-rs/frontend/src/components/FileTree.js
@@ -1,0 +1,128 @@
+import { readDir, readTextFile, writeFile, createDir } from "@tauri-apps/api/fs";
+
+export class FileTree {
+  constructor(container, root = ".") {
+    this.container = container;
+    this.root = root;
+    this.selected = null;
+    this.menu = this.#buildMenu();
+    document.body.appendChild(this.menu);
+    this.rootEntry = { path: this.root, children: true };
+    this.container.addEventListener("click", () => this.#hideMenu());
+    this.container.addEventListener("contextmenu", (e) => {
+      e.preventDefault();
+      this.#showMenu(e, this.rootEntry);
+    });
+    window.addEventListener("click", () => this.#hideMenu());
+    this.refresh();
+  }
+
+  async refresh() {
+    this.container.innerHTML = "";
+    const entries = await readDir(this.root, { recursive: true });
+    const ul = document.createElement("ul");
+    this.#buildTree(entries, ul);
+    this.container.appendChild(ul);
+  }
+
+  #buildTree(entries, parent) {
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+    for (const entry of entries) {
+      const li = document.createElement("li");
+      li.textContent = entry.name;
+      li.dataset.path = entry.path;
+      li.addEventListener("click", (e) => {
+        e.stopPropagation();
+        this.#select(li);
+      });
+      li.addEventListener("contextmenu", (e) => {
+        e.preventDefault();
+        this.#showMenu(e, entry);
+      });
+      parent.appendChild(li);
+      if (entry.children) {
+        const child = document.createElement("ul");
+        li.appendChild(child);
+        this.#buildTree(entry.children, child);
+      }
+    }
+  }
+
+  #select(li) {
+    if (this.selected) this.selected.classList.remove("selected");
+    this.selected = li;
+    li.classList.add("selected");
+    window.dispatchEvent(
+      new CustomEvent("file-selected", { detail: { path: li.dataset.path } })
+    );
+  }
+
+  #buildMenu() {
+    const menu = document.createElement("div");
+    menu.style.position = "absolute";
+    menu.style.display = "none";
+    menu.style.background = "#fff";
+    menu.style.border = "1px solid #ccc";
+    const open = document.createElement("div");
+    open.textContent = "Open";
+    open.addEventListener("click", () => this.#open());
+    const refresh = document.createElement("div");
+    refresh.textContent = "Refresh";
+    refresh.addEventListener("click", () => this.refresh());
+    const newFile = document.createElement("div");
+    newFile.textContent = "New File";
+    newFile.addEventListener("click", () => this.#newFile());
+    const newFolder = document.createElement("div");
+    newFolder.textContent = "New Folder";
+    newFolder.addEventListener("click", () => this.#newFolder());
+    menu.append(open, refresh, newFile, newFolder);
+    return menu;
+  }
+
+  #showMenu(e, entry) {
+    this.contextEntry = entry;
+    this.menu.style.left = `${e.pageX}px`;
+    this.menu.style.top = `${e.pageY}px`;
+    this.menu.style.display = "block";
+  }
+
+  #hideMenu() {
+    this.menu.style.display = "none";
+    this.contextEntry = null;
+  }
+
+  async #open() {
+    if (!this.contextEntry || this.contextEntry.children) return;
+    const content = await readTextFile(this.contextEntry.path);
+    window.dispatchEvent(
+      new CustomEvent("file-open", {
+        detail: { path: this.contextEntry.path, content },
+      })
+    );
+    this.#hideMenu();
+  }
+
+  async #newFile() {
+    if (!this.contextEntry) return;
+    const name = prompt("File name?");
+    if (!name) return this.#hideMenu();
+    const base = this.contextEntry.children
+      ? this.contextEntry.path
+      : this.contextEntry.path.split("/").slice(0, -1).join("/");
+    await writeFile({ path: `${base}/${name}`, contents: "" });
+    await this.refresh();
+    this.#hideMenu();
+  }
+
+  async #newFolder() {
+    if (!this.contextEntry) return;
+    const name = prompt("Folder name?");
+    if (!name) return this.#hideMenu();
+    const base = this.contextEntry.children
+      ? this.contextEntry.path
+      : this.contextEntry.path.split("/").slice(0, -1).join("/");
+    await createDir(`${base}/${name}`, { recursive: true });
+    await this.refresh();
+    this.#hideMenu();
+  }
+}


### PR DESCRIPTION
## Summary
- add FileTree component using Tauri fs API to render directory tree and context menu actions
- wire FileTree into frontend and display file contents on open
- clean up sidebar markup

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68be4ab49cd48324af4571263d2c9900