### PR TITLE
feat: add chat panel with codex streaming

### DIFF
--- a/codex-rs/frontend/index.html
+++ b/codex-rs/frontend/index.html
@@ -24,7 +24,22 @@
       overflow: auto;
     }
     #chat {
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+    #chat .messages {
+      flex: 1;
       overflow: auto;
+      padding: 8px;
+    }
+    #chat .input-row {
+      display: flex;
+      gap: 4px;
+      padding: 8px;
+    }
+    #chat .input-row input {
+      flex: 1;
     }
     .selected {
       background: #ddd;
@@ -43,11 +58,7 @@
         <textarea id="patch" placeholder="Patch text"></textarea>
         <button id="apply">Apply Patch</button>
       </div>
-      <div id="chat">
-        <input id="prompt" type="text" placeholder="Enter prompt" />
-        <button id="send">Send</button>
-        <pre id="response"></pre>
-      </div>
+      <div id="chat"></div>
     </div>
     <div id="settings-panel" style="display:none"></div>
   </div>

--- a/codex-rs/frontend/main.js
+++ b/codex-rs/frontend/main.js
@@ -2,28 +2,12 @@ import { invoke } from "@tauri-apps/api/tauri";
 import { SettingsPanel } from "./settings_panel.js";
 import { MainLayout } from "./src/main_layout.js";
 import { FileTree } from "./src/components/FileTree.js";
+import { ChatPanel } from "./src/components/ChatPanel.js";
 
 new MainLayout();
 
 const fileTree = new FileTree(document.getElementById("file-tree"));
-
-let conversationId = null;
-
-async function ensureConversation() {
-  if (!conversationId) {
-    conversationId = await invoke("start_conversation");
-  }
-}
-
-document.getElementById("send").addEventListener("click", async () => {
-  await ensureConversation();
-  const prompt = document.getElementById("prompt").value;
-  await invoke("send_message", { id: conversationId, message: prompt });
-});
-
-window.addEventListener("file-open", (e) => {
-  document.getElementById("response").textContent = e.detail.content;
-});
+new ChatPanel(document.getElementById("chat"));
 
 document.getElementById("apply").addEventListener("click", async () => {
   const patch = document.getElementById("patch").value;
@@ -31,7 +15,7 @@ document.getElementById("apply").addEventListener("click", async () => {
 });
 
 const settingsPanel = new SettingsPanel(
-  document.getElementById("settings-panel")
+  document.getElementById("settings-panel"),
 );
 document
   .getElementById("open-settings")

--- a/codex-rs/frontend/src/components/ChatPanel.js
+++ b/codex-rs/frontend/src/components/ChatPanel.js
@@ -1,0 +1,93 @@
+import { invoke } from "@tauri-apps/api/tauri";
+import { listen } from "@tauri-apps/api/event";
+import { readTextFile, writeFile, createDir } from "@tauri-apps/api/fs";
+
+export class ChatPanel {
+  constructor(container, root = ".") {
+    this.container = container;
+    this.root = root;
+    this.messages = [];
+    this.selectedFile = null;
+
+    this.container.innerHTML = `
+      <div class="messages"></div>
+      <div class="input-row">
+        <button id="insert-file">Insert File</button>
+        <input id="chat-input" type="text" placeholder="Enter message" />
+        <button id="chat-send">Send</button>
+      </div>
+    `;
+
+    this.list = this.container.querySelector(".messages");
+    this.input = this.container.querySelector("#chat-input");
+    this.send = this.container.querySelector("#chat-send");
+    this.insert = this.container.querySelector("#insert-file");
+
+    this.send.addEventListener("click", () => this.submit());
+    this.insert.addEventListener("click", () => this.insertFile());
+
+    window.addEventListener("file-selected", (e) => {
+      this.selectedFile = e.detail.path;
+    });
+
+    this.loadHistory();
+  }
+
+  renderMessage(role, text) {
+    const div = document.createElement("div");
+    div.className = role;
+    div.textContent = text;
+    this.list.appendChild(div);
+    this.list.scrollTop = this.list.scrollHeight;
+    return div;
+  }
+
+  async loadHistory() {
+    try {
+      const text = await readTextFile(`${this.root}/.codex/history.json`);
+      this.messages = JSON.parse(text);
+      for (const m of this.messages) {
+        this.renderMessage(m.role, m.content);
+      }
+    } catch (_) {
+      this.messages = [];
+    }
+  }
+
+  async saveHistory() {
+    await createDir(`${this.root}/.codex`, { recursive: true });
+    await writeFile({
+      path: `${this.root}/.codex/history.json`,
+      contents: JSON.stringify(this.messages),
+    });
+  }
+
+  async insertFile() {
+    if (!this.selectedFile) return;
+    const content = await readTextFile(this.selectedFile);
+    this.input.value += `\n${content}\n`;
+  }
+
+  async submit() {
+    const text = this.input.value;
+    if (!text.trim()) return;
+    this.input.value = "";
+
+    this.messages.push({ role: "user", content: text });
+    this.renderMessage("user", text);
+
+    const assistant = { role: "assistant", content: "" };
+    this.messages.push(assistant);
+    const div = this.renderMessage("assistant", "");
+
+    const unlisten = await listen("codex", (event) => {
+      assistant.content += event.payload;
+      div.textContent = assistant.content;
+      this.list.scrollTop = this.list.scrollHeight;
+    });
+
+    await invoke("run_codex", { input: text });
+    unlisten();
+    await this.saveHistory();
+  }
+}


### PR DESCRIPTION
## Summary
- add ChatPanel component with message list and file insertion
- stream responses from new `run_codex` command
- store chat history per project

## Testing
- `pnpm format`
- `cargo fmt`
- `just fix -p frontend` *(fails: command not found)*
- `cargo test -p codex-frontend` *(fails: The system library `gobject-2.0` required by crate `gobject-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be4c6623208324b77500a7a5aeaf28