### PR TITLE
feat(frontend): add command palette with fuzzy search

### DIFF
--- a/codex-rs/frontend/main.js
+++ b/codex-rs/frontend/main.js
@@ -4,12 +4,20 @@ import { MainLayout } from "./src/main_layout.js";
 import { FileTree } from "./src/components/FileTree.js";
 import { ChatPanel } from "./src/components/ChatPanel.js";
 import { AuthModal } from "./src/components/AuthModal.js";
-import { workspace, saveWorkspace, resetWorkspace } from "./src/state/workspace.ts";
+import { CommandPalette } from "./src/components/CommandPalette.tsx";
+import { writeFile } from "@tauri-apps/api/fs";
+import {
+  workspace,
+  saveWorkspace,
+  resetWorkspace,
+} from "./src/state/workspace.ts";
 
 new MainLayout();
 
 const fileTree = new FileTree(document.getElementById("file-tree"));
 new ChatPanel(document.getElementById("chat"));
+
+const palette = new CommandPalette(".");
 
 window.addEventListener("file-open", (e) => {
   const { path, content } = e.detail;
@@ -48,3 +56,17 @@ document
     await resetWorkspace();
     window.location.reload();
   });
+
+window.addEventListener("command", async (e) => {
+  const name = e.detail;
+  if (name === "ask-codex") {
+    document.getElementById("chat-input")?.focus();
+  } else if (name === "new-file") {
+    const filename = prompt("File name?");
+    if (!filename) return;
+    await writeFile({ path: filename, contents: "" });
+    window.dispatchEvent(
+      new CustomEvent("file-open", { detail: { path: filename, content: "" } }),
+    );
+  }
+});

--- a/codex-rs/frontend/package.json
+++ b/codex-rs/frontend/package.json
@@ -5,7 +5,8 @@
     "@tauri-apps/api": "^1.5.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-diff-view": "^3.2.2"
+    "react-diff-view": "^3.2.2",
+    "fuse.js": "^7.0.0"
   },
   "scripts": {
     "dev": "cargo tauri dev"

--- a/codex-rs/frontend/src/components/CommandPalette.tsx
+++ b/codex-rs/frontend/src/components/CommandPalette.tsx
@@ -1,0 +1,130 @@
+import Fuse from "fuse.js";
+import { readDir, readTextFile } from "@tauri-apps/api/fs";
+import {
+  builtinCommands,
+  commandState,
+  recordCommand,
+} from "../state/commands.ts";
+
+interface Item {
+  type: "file" | "command";
+  name: string;
+}
+
+export class CommandPalette {
+  root: string;
+  element: HTMLDivElement;
+  input: HTMLInputElement;
+  list: HTMLUListElement;
+  items: Item[] = [];
+  fuse!: Fuse<Item>;
+  current: Item[] = [];
+
+  constructor(root = ".") {
+    this.root = root;
+    this.element = document.createElement("div");
+    this.element.id = "command-palette";
+    this.element.style.display = "none";
+    this.element.innerHTML = `
+      <input id="cmd-input" type="text" placeholder="Type a command or file" />
+      <ul id="cmd-results"></ul>
+    `;
+    document.body.appendChild(this.element);
+    this.input = this.element.querySelector("#cmd-input") as HTMLInputElement;
+    this.list = this.element.querySelector("#cmd-results") as HTMLUListElement;
+
+    this.input.addEventListener("input", () => this.search());
+    this.input.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") this.choose();
+      if (e.key === "Escape") this.close();
+    });
+
+    window.addEventListener("keydown", (e) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "p") {
+        e.preventDefault();
+        this.open();
+      }
+    });
+
+    this.index();
+  }
+
+  async index() {
+    const entries = await readDir(this.root, { recursive: true });
+    const files: string[] = [];
+    const walk = (ents: any[]) => {
+      for (const e of ents) {
+        if (e.children) walk(e.children);
+        else files.push(e.path);
+      }
+    };
+    walk(entries);
+    this.items = [
+      ...files.map((p) => ({ type: "file", name: p }) as Item),
+      ...builtinCommands.map(
+        (c) => ({ type: "command", name: c.name }) as Item,
+      ),
+    ];
+    this.fuse = new Fuse(this.items, { keys: ["name"], threshold: 0.4 });
+  }
+
+  open() {
+    this.element.style.display = "block";
+    this.input.value = "";
+    this.search();
+    this.input.focus();
+  }
+
+  close() {
+    this.element.style.display = "none";
+  }
+
+  search() {
+    const q = this.input.value.trim();
+    let results: Item[];
+    if (!q) {
+      results = [
+        ...commandState.recent.map(
+          (n) => ({ type: "command", name: n }) as Item,
+        ),
+        ...builtinCommands
+          .filter((c) => !commandState.recent.includes(c.name))
+          .map((c) => ({ type: "command", name: c.name }) as Item),
+      ];
+    } else {
+      results = this.fuse.search(q).map((r) => r.item);
+    }
+    this.render(results.slice(0, 10));
+  }
+
+  render(items: Item[]) {
+    this.list.innerHTML = "";
+    this.current = items;
+    for (const item of items) {
+      const li = document.createElement("li");
+      li.textContent = item.name;
+      li.addEventListener("click", () => this.activate(item));
+      this.list.appendChild(li);
+    }
+  }
+
+  choose() {
+    if (this.current.length > 0) this.activate(this.current[0]);
+  }
+
+  async activate(item: Item) {
+    if (item.type === "file") {
+      const content = await readTextFile(item.name);
+      window.dispatchEvent(
+        new CustomEvent("file-open", { detail: { path: item.name, content } }),
+      );
+    } else {
+      const cmd = builtinCommands.find((c) => c.name === item.name);
+      if (cmd) {
+        cmd.action();
+        recordCommand(cmd.name);
+      }
+    }
+    this.close();
+  }
+}

--- a/codex-rs/frontend/src/state/commands.ts
+++ b/codex-rs/frontend/src/state/commands.ts
@@ -1,0 +1,57 @@
+import { readTextFile, writeFile, createDir } from "@tauri-apps/api/fs";
+import { homeDir, join } from "@tauri-apps/api/path";
+
+export interface CommandState {
+  recent: string[];
+}
+
+function defaultState(): CommandState {
+  return { recent: [] };
+}
+
+async function commandsPath(): Promise<string> {
+  const home = await homeDir();
+  return await join(home, ".config", "codex-frontend", "commands.json");
+}
+
+export const commandState: CommandState = await (async () => {
+  try {
+    const text = await readTextFile(await commandsPath());
+    return { ...defaultState(), ...JSON.parse(text) } as CommandState;
+  } catch {
+    return defaultState();
+  }
+})();
+
+export async function saveCommands(): Promise<void> {
+  const path = await commandsPath();
+  const dir = await join(await homeDir(), ".config", "codex-frontend");
+  await createDir(dir, { recursive: true });
+  await writeFile({ path, contents: JSON.stringify(commandState) });
+}
+
+export function recordCommand(name: string): void {
+  const idx = commandState.recent.indexOf(name);
+  if (idx !== -1) commandState.recent.splice(idx, 1);
+  commandState.recent.unshift(name);
+  if (commandState.recent.length > 20) commandState.recent.pop();
+  void saveCommands();
+}
+
+export interface BuiltinCommand {
+  name: string;
+  action: () => void | Promise<void>;
+}
+
+export const builtinCommands: BuiltinCommand[] = [
+  {
+    name: "Ask Codex",
+    action: () =>
+      window.dispatchEvent(new CustomEvent("command", { detail: "ask-codex" })),
+  },
+  {
+    name: "New File",
+    action: () =>
+      window.dispatchEvent(new CustomEvent("command", { detail: "new-file" })),
+  },
+];


### PR DESCRIPTION
## Summary
- add fuse.js dependency and wire up command palette to open with Ctrl+P
- track and persist recent commands
- enable quick-open files and commands like "Ask Codex" and "New File"

## Testing
- `npx prettier --check codex-rs/frontend/package.json codex-rs/frontend/src/state/commands.ts codex-rs/frontend/src/components/CommandPalette.tsx codex-rs/frontend/main.js`

------
https://chatgpt.com/codex/tasks/task_e_68be56aa05508324984761a108978994