### PR TITLE
feat: add terminal panel with xterm

### DIFF
--- a/codex-rs/frontend/main.js
+++ b/codex-rs/frontend/main.js
@@ -6,6 +6,7 @@ import { ChatPanel } from "./src/components/ChatPanel.js";
 import { AuthModal } from "./src/components/AuthModal.js";
 import { CommandPalette } from "./src/components/CommandPalette.tsx";
 import { writeFile } from "@tauri-apps/api/fs";
+import { TerminalPanel } from "./src/components/TerminalPanel.tsx";
 import {
   workspace,
   saveWorkspace,
@@ -18,6 +19,7 @@ const fileTree = new FileTree(document.getElementById("file-tree"));
 new ChatPanel(document.getElementById("chat"));
 
 const palette = new CommandPalette(".");
+new TerminalPanel();
 
 window.addEventListener("file-open", (e) => {
   const { path, content } = e.detail;

--- a/codex-rs/frontend/package.json
+++ b/codex-rs/frontend/package.json
@@ -6,7 +6,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-diff-view": "^3.2.2",
-    "fuse.js": "^7.0.0"
+    "fuse.js": "^7.0.0",
+    "xterm": "^5.3.0"
   },
   "scripts": {
     "dev": "cargo tauri dev"

--- a/codex-rs/frontend/src/components/TerminalPanel.tsx
+++ b/codex-rs/frontend/src/components/TerminalPanel.tsx
@@ -1,0 +1,105 @@
+import { Command } from "@tauri-apps/api/shell";
+import { Terminal } from "xterm";
+import "xterm/css/xterm.css";
+
+interface Session {
+  term: Terminal;
+  child: any;
+  container: HTMLDivElement;
+  tab: HTMLDivElement;
+}
+
+export class TerminalPanel {
+  element: HTMLDivElement;
+  tabs: HTMLDivElement;
+  sessions: Session[] = [];
+  active = -1;
+
+  constructor() {
+    this.element = document.createElement("div");
+    this.element.id = "terminal-panel";
+    Object.assign(this.element.style, {
+      position: "fixed",
+      inset: "0",
+      display: "none",
+      flexDirection: "column",
+      background: "#000",
+      zIndex: "1000",
+    });
+
+    this.tabs = document.createElement("div");
+    Object.assign(this.tabs.style, {
+      display: "flex",
+      background: "#333",
+    });
+    this.element.appendChild(this.tabs);
+
+    document.body.appendChild(this.element);
+
+    const add = document.createElement("button");
+    add.textContent = "+";
+    add.addEventListener("click", () => this.newSession());
+    this.tabs.appendChild(add);
+
+    window.addEventListener("keydown", (e) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === "`") {
+        e.preventDefault();
+        this.toggle();
+      }
+    });
+
+    this.newSession();
+  }
+
+  toggle() {
+    if (this.element.style.display === "none") {
+      this.element.style.display = "flex";
+      this.sessions[this.active]?.term.focus();
+    } else {
+      this.element.style.display = "none";
+    }
+  }
+
+  async newSession() {
+    const idx = this.sessions.length;
+    const tab = document.createElement("div");
+    tab.textContent = `Shell ${idx + 1}`;
+    Object.assign(tab.style, {
+      padding: "4px 8px",
+      cursor: "pointer",
+    });
+    tab.addEventListener("click", () => this.activate(idx));
+    this.tabs.insertBefore(tab, this.tabs.lastElementChild);
+
+    const container = document.createElement("div");
+    container.style.flex = "1";
+    container.style.display = "none";
+    this.element.appendChild(container);
+
+    const term = new Terminal();
+    term.open(container);
+
+    const command = new Command("sh", [], { cwd: "." });
+    const child = await command.spawn();
+    child.stdout.on("data", (line: string) => term.write(line));
+    child.stderr.on("data", (line: string) => term.write(line));
+    term.onData((d) => child.write(d));
+    child.on("close", () => term.write("\r\n[process exited]\r\n"));
+
+    this.sessions.push({ term, child, container, tab });
+    this.activate(idx);
+  }
+
+  activate(idx: number) {
+    if (this.active >= 0) {
+      const prev = this.sessions[this.active];
+      prev.container.style.display = "none";
+      prev.tab.style.background = "";
+    }
+    const sess = this.sessions[idx];
+    sess.container.style.display = "block";
+    sess.tab.style.background = "#555";
+    this.active = idx;
+    sess.term.focus();
+  }
+}


### PR DESCRIPTION
## Summary
- add xterm dependency and terminal panel component
- spawn shell via Tauri Command and pipe to xterm
- hook terminal panel with keyboard toggle and tabbed sessions

## Testing
- `pnpm add xterm --filter codex-frontend` *(fails: GET https://registry.npmjs.org/react: Forbidden - 403)*
- `pnpm exec prettier codex-rs/frontend/package.json codex-rs/frontend/main.js codex-rs/frontend/src/components/TerminalPanel.tsx --write`
- `pnpm format` *(fails: Code style issues found in 5 files. Run Prettier with --write to fix.)*


------
https://chatgpt.com/codex/tasks/task_e_68be5788e2308324a26248f874e8b48f