### PR TITLE
Launch Codex GUI by default and add --cli flag

### DIFF
--- a/codex-cli/bin/codex.js
+++ b/codex-cli/bin/codex.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-// Unified entry point for the Codex CLI.
+// Unified entry point for Codex. Launches the GUI by default and falls back to
+// the CLI when flags are provided or the `--cli` flag is used.
 
 import path from "path";
 import { fileURLToPath } from "url";
@@ -57,7 +58,19 @@ if (!targetTriple) {
   throw new Error(`Unsupported platform: ${platform} (${arch})`);
 }
 
-const binaryPath = path.join(__dirname, "..", "bin", `codex-${targetTriple}`);
+const binDir = path.join(__dirname, "..", "bin");
+
+const args = process.argv.slice(2);
+const cliFlagIndex = args.indexOf("--cli");
+const useCli = cliFlagIndex !== -1 || args.length > 0;
+if (cliFlagIndex !== -1) {
+  args.splice(cliFlagIndex, 1);
+}
+
+const binaryPath = path.join(
+  binDir,
+  `${useCli ? "codex" : "codex-frontend"}-${targetTriple}`,
+);
 
 // Use an asynchronous spawn instead of spawnSync so that Node is able to
 // respond to signals (e.g. Ctrl-C / SIGINT) while the native binary is
@@ -100,7 +113,7 @@ if (rgDir) {
 }
 const updatedPath = getUpdatedPath(additionalDirs);
 
-const child = spawn(binaryPath, process.argv.slice(2), {
+const child = spawn(binaryPath, args, {
   stdio: "inherit",
   env: { ...process.env, PATH: updatedPath, CODEX_MANAGED_BY_NPM: "1" },
 });

--- a/docs/install.md
+++ b/docs/install.md
@@ -12,6 +12,11 @@
 
 The GitHub Release also contains a [DotSlash](https://dotslash-cli.com/) file for the Codex CLI named `codex`. Using a DotSlash file makes it possible to make a lightweight commit to source control to ensure all contributors use the same version of an executable, regardless of what platform they use for development.
 
+### Launch modes
+
+Running `codex` without arguments opens the graphical interface. Use `--cli` or any
+other CLI flags to run the terminal version for headless usage.
+
 ### Build from source
 
 ```bash
@@ -37,4 +42,4 @@ cargo clippy --tests
 
 # Run the tests.
 cargo test
-``` 
+```


### PR DESCRIPTION
## Summary
- default `codex` command to spawn the Tauri frontend when run without arguments
- add `--cli` flag to force terminal mode
- document GUI-first launch behavior and new `--cli` flag

## Testing
- ⚠️ `pnpm format` (code style issues found in unrelated files)
- ✅ `npx prettier --check codex-cli/bin/codex.js docs/install.md`
- ✅ `node --check codex-cli/bin/codex.js`


------
https://chatgpt.com/codex/tasks/task_e_68be5bfac3808324ae0eb7b2e061f3ca