### PR TITLE
feat(frontend): expose CLI subcommands to tauri

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -978,6 +978,7 @@ dependencies = [
  "codex-apply-patch",
  "codex-core",
  "codex-file-search",
+ "codex-login",
  "serde",
  "serde_json",
  "tauri",

--- a/codex-rs/frontend/Cargo.toml
+++ b/codex-rs/frontend/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 codex-core = { path = "../core" }
 codex-file-search = { path = "../file-search" }
 codex-apply-patch = { path = "../apply-patch" }
+codex-login = { path = "../login" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "1", features = [] }

--- a/codex-rs/frontend/src/api.ts
+++ b/codex-rs/frontend/src/api.ts
@@ -1,0 +1,36 @@
+import { invoke } from "@tauri-apps/api/tauri";
+
+export interface CommandStatus {
+  code: number;
+}
+
+export interface SearchFilesResult extends CommandStatus {
+  paths: string[];
+}
+
+export interface LoginResult extends CommandStatus {
+  token?: string;
+}
+
+export function runCodex(input: string, context?: string): Promise<CommandStatus> {
+  return invoke("run_codex", { input, context });
+}
+
+export function searchFiles(query: string, dir: string): Promise<SearchFilesResult> {
+  return invoke("search_files", { query, dir });
+}
+
+export function applyPatch(patch: string): Promise<CommandStatus> {
+  return invoke("apply_patch_command", { patch });
+}
+
+export function loginWithApiKey(apiKey: string): Promise<LoginResult> {
+  return invoke("login_with_api_key", { apiKey });
+}
+
+export function loginWithCredentials(
+  username: string,
+  password: string,
+): Promise<LoginResult> {
+  return invoke("login_with_credentials", { username, password });
+}


### PR DESCRIPTION
## Summary
- expose CLI operations as Tauri commands that stream output and return exit codes
- add `codex-login` dependency and implement login commands
- document invocation schemas in new `frontend/src/api.ts`

## Testing
- `cargo clippy -p codex-frontend --fix --allow-dirty --allow-staged --all-features --tests` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*
- `cargo test -p codex-frontend` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*
- `pnpm format` *(fails: Code style issues found in 5 files. Run Prettier with --write to fix.)*


------
https://chatgpt.com/codex/tasks/task_e_68be5d3264688324907c417d37dd9083