### PR TITLE
Add settings and auth dialogs with toolbar integration

### DIFF
--- a/codex-rs/frontend/index.html
+++ b/codex-rs/frontend/index.html
@@ -13,6 +13,7 @@
       gap: 8px;
       padding: 8px;
       background: #eee;
+      align-items: center;
     }
     #layout {
       display: grid;
@@ -50,8 +51,11 @@
   <div id="app">
     <div id="header">
       <button id="toggle-sidebar">Hide Sidebar</button>
-      <button id="open-settings">Settings</button>
-      <button id="reset-workspace">Reset Workspace</button>
+      <div style="margin-left:auto;display:flex;gap:8px;">
+        <button id="open-auth">Auth</button>
+        <button id="open-settings">Settings</button>
+        <button id="reset-workspace">Reset Workspace</button>
+      </div>
     </div>
     <div id="layout">
       <div id="sidebar">
@@ -61,7 +65,6 @@
       </div>
       <div id="chat"></div>
     </div>
-    <div id="settings-panel" style="display:none"></div>
   </div>
   <script type="module" src="main.js"></script>
 </body>

--- a/codex-rs/frontend/main.js
+++ b/codex-rs/frontend/main.js
@@ -1,9 +1,9 @@
 import { invoke } from "@tauri-apps/api/tauri";
-import { SettingsPanel } from "./src/components/SettingsPanel.js";
+import { SettingsDialog } from "./src/components/SettingsDialog.tsx";
 import { MainLayout } from "./src/main_layout.js";
 import { FileTree } from "./src/components/FileTree.js";
 import { ChatPanel } from "./src/components/ChatPanel.tsx";
-import { AuthModal } from "./src/components/AuthModal.js";
+import { AuthDialog } from "./src/components/AuthDialog.tsx";
 import { CommandPalette } from "./src/components/CommandPalette.tsx";
 import { writeFile } from "@tauri-apps/api/fs";
 import { TerminalPanel } from "./src/components/TerminalPanel.tsx";
@@ -36,20 +36,22 @@ const saveOnExit = () => {
 };
 window.addEventListener("beforeunload", saveOnExit);
 
-const authModal = new AuthModal();
-authModal.open();
+const authDialog = new AuthDialog();
+authDialog.open();
 
 document.getElementById("apply").addEventListener("click", async () => {
   const patch = document.getElementById("patch").value;
   await invoke("apply_patch_command", { patch });
 });
 
-const settingsPanel = new SettingsPanel(
-  document.getElementById("settings-panel"),
-);
+const settingsDialog = new SettingsDialog();
 document
   .getElementById("open-settings")
-  .addEventListener("click", () => settingsPanel.open());
+  ?.addEventListener("click", () => settingsDialog.open());
+
+document
+  .getElementById("open-auth")
+  ?.addEventListener("click", () => authDialog.open());
 
 document
   .getElementById("reset-workspace")

--- a/codex-rs/frontend/src/components/AuthDialog.tsx
+++ b/codex-rs/frontend/src/components/AuthDialog.tsx
@@ -1,0 +1,62 @@
+import { invoke } from "@tauri-apps/api/tauri";
+import { secureStorage } from "@tauri-apps/plugin-secure-storage";
+
+export class AuthDialog {
+  private el: HTMLDivElement;
+
+  constructor() {
+    this.el = document.createElement("div");
+    Object.assign(this.el.style, {
+      position: "fixed",
+      inset: "0",
+      background: "rgba(0,0,0,0.5)",
+      display: "none",
+      alignItems: "center",
+      justifyContent: "center",
+      zIndex: "1000",
+    });
+
+    this.el.innerHTML = `
+      <div style="background:white;padding:16px;border-radius:8px;display:flex;flex-direction:column;gap:8px;min-width:300px;">
+        <h2>Authenticate</h2>
+        <div class="api-key" style="display:flex;gap:8px;flex-direction:column;">
+          <input id="api-key" type="text" placeholder="API Key" />
+          <button id="submit-key">Use API Key</button>
+        </div>
+        <div class="oauth" style="display:flex;flex-direction:column;gap:8px;">
+          <button id="oauth-login">Login with OAuth</button>
+        </div>
+      </div>
+    `;
+
+    document.body.appendChild(this.el);
+
+    this.el.querySelector("#submit-key")?.addEventListener("click", () => this.submitApiKey());
+    this.el.querySelector("#oauth-login")?.addEventListener("click", () => this.submitOAuth());
+  }
+
+  open() {
+    this.el.style.display = "flex";
+  }
+
+  close() {
+    this.el.style.display = "none";
+  }
+
+  private async submitApiKey() {
+    const apiKey = (this.el.querySelector("#api-key") as HTMLInputElement).value.trim();
+    if (!apiKey) return;
+    const token = await invoke("login_with_api_key", { apiKey });
+    await secureStorage.set("auth_token", (token as string) || apiKey);
+    this.close();
+  }
+
+  private async submitOAuth() {
+    const token = await invoke("login_with_credentials", {});
+    if (token) {
+      await secureStorage.set("auth_token", token as string);
+      this.close();
+    }
+  }
+}
+

--- a/codex-rs/frontend/src/components/SettingsDialog.tsx
+++ b/codex-rs/frontend/src/components/SettingsDialog.tsx
@@ -1,0 +1,78 @@
+import { invoke } from "@tauri-apps/api/tauri";
+
+interface Settings {
+  model: string;
+  model_max_output_tokens?: number | null;
+  disable_response_storage: boolean;
+  hide_agent_reasoning: boolean;
+}
+
+export class SettingsDialog {
+  private el: HTMLDivElement;
+
+  constructor() {
+    this.el = document.createElement("div");
+    Object.assign(this.el.style, {
+      position: "fixed",
+      inset: "0",
+      background: "rgba(0,0,0,0.5)",
+      display: "none",
+      alignItems: "center",
+      justifyContent: "center",
+      zIndex: "1000",
+    });
+
+    this.el.innerHTML = `
+      <div style="background:white;padding:16px;border-radius:8px;display:flex;flex-direction:column;gap:8px;min-width:300px;">
+        <h2>Settings</h2>
+        <label>Model: <input id="model" type="text" /></label>
+        <label>Max Output Tokens: <input id="max_tokens" type="number" min="0" /></label>
+        <label><input id="disable_response_storage" type="checkbox" /> Disable Response Storage</label>
+        <label><input id="hide_agent_reasoning" type="checkbox" /> Hide Agent Reasoning</label>
+        <div style="display:flex;gap:8px;justify-content:flex-end;">
+          <button id="save-settings">Save</button>
+          <button id="close-settings">Close</button>
+        </div>
+      </div>
+    `;
+
+    document.body.appendChild(this.el);
+
+    this.el.querySelector("#save-settings")?.addEventListener("click", () => this.save());
+    this.el.querySelector("#close-settings")?.addEventListener("click", () => this.close());
+  }
+
+  async open() {
+    this.el.style.display = "flex";
+    const settings = (await invoke("load_settings")) as Settings;
+    (this.el.querySelector("#model") as HTMLInputElement).value = settings.model || "";
+    const max = settings.model_max_output_tokens ?? "";
+    (this.el.querySelector("#max_tokens") as HTMLInputElement).value = max.toString();
+    (this.el.querySelector("#disable_response_storage") as HTMLInputElement).checked =
+      !!settings.disable_response_storage;
+    (this.el.querySelector("#hide_agent_reasoning") as HTMLInputElement).checked =
+      !!settings.hide_agent_reasoning;
+  }
+
+  close() {
+    this.el.style.display = "none";
+  }
+
+  async save() {
+    const model = (this.el.querySelector("#model") as HTMLInputElement).value;
+    const maxTokensStr = (this.el.querySelector("#max_tokens") as HTMLInputElement).value;
+    const model_max_output_tokens = maxTokensStr ? parseInt(maxTokensStr, 10) : undefined;
+    const disable_response_storage = (this.el.querySelector("#disable_response_storage") as HTMLInputElement).checked;
+    const hide_agent_reasoning = (this.el.querySelector("#hide_agent_reasoning") as HTMLInputElement).checked;
+    await invoke("save_settings", {
+      settings: {
+        model,
+        model_max_output_tokens,
+        disable_response_storage,
+        hide_agent_reasoning,
+      },
+    });
+    this.close();
+  }
+}
+

--- a/codex-rs/frontend/src/main.rs
+++ b/codex-rs/frontend/src/main.rs
@@ -248,6 +248,7 @@ struct FrontendSettings {
     model: Option<String>,
     disable_response_storage: Option<bool>,
     hide_agent_reasoning: Option<bool>,
+    model_max_output_tokens: Option<u64>,
 }
 
 #[tauri::command]
@@ -263,6 +264,9 @@ fn save_settings(settings: FrontendSettings) -> Result<(), String> {
     }
     if let Some(hide) = settings.hide_agent_reasoning {
         root["hide_agent_reasoning"] = TomlValue::Boolean(hide);
+    }
+    if let Some(tokens) = settings.model_max_output_tokens {
+        root["model_max_output_tokens"] = TomlValue::Integer(tokens as i64);
     }
 
     std::fs::create_dir_all(&codex_home).map_err(|e| e.to_string())?;


### PR DESCRIPTION
## Summary
- Replace old settings panel with a modal SettingsDialog supporting model selection, output token limits, and response display options.
- Introduce an AuthDialog for API key entry or OAuth login stored securely via Tauri's secure storage.
- Wire both dialogs into a new top-right toolbar for easy access.

## Testing
- `cargo fmt`
- `cargo clippy -p codex-frontend` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found.)*
- `cargo test -p codex-frontend` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found.)*

------
https://chatgpt.com/codex/tasks/task_e_68be619185ac8324a773f4c52f4895fe